### PR TITLE
Replace invalid module "coreaudio" with "alsa".

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure(2) do |config|
   config.vm.provider :virtualbox do |vb|
     vb.customize [
       "modifyvm", :id,
-      "--audio",           "coreaudio",
+      "--audio",           "alsa",
       "--audiocontroller", "hda"
     ]
   end


### PR DESCRIPTION
Apparently "coreaudio" is for MacOS hosts. "Alsa" or "pulse" are commonly used on linux. This is all according to
https://github.com/paulsturgess/mopidy-vagrant/issues/3. This patch replaces "coreaudio" with "alsa", and in fact that enables the vagrant machine to successfully build and run, resolving https://github.com/ains/aircast/issues/10 .

I am not able to confirm that the result works on my network, however. iTunes on my laptop is not seeing any additional AirPlay devices when the virtual machine is running on my home server machine, but at least the virtual machine runs.